### PR TITLE
Add switch to enable logging to a file instead of stdout

### DIFF
--- a/focus.py
+++ b/focus.py
@@ -326,9 +326,15 @@ class ForwardedDNS(object):
 
 
 if __name__ == "__main__":
+
+    logfile = None
+    if sys.argv[1] == "--logfile":
+        logfile = sys.argv[2]
+
     logging.basicConfig(
         format="(%(process)d) %(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        level=logging.INFO
+        level=logging.INFO,
+        filename=logfile or ""
     )
     log = logging.getLogger("server")
     


### PR DESCRIPTION
For daemons, you want to log to a file in stead of stdout. This could be
solved by using pipes, but it could be considered cleaner to let the
logging module do this itself.
