### PR TITLE
Added instructions how to get Focus working on Mac OS X.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,20 @@ def domain_reddit_com(dt):
 Starting
 ========
 
+### Linux
+
 Add the following line to the top of your `/etc/resolv.conf`, *before* any
 other nameservers:
 
     nameserver 127.0.0.1
-    
+
+### Mac OS X
+
+Go to `System Preferences -> Network -> Advanced -> DNS` and add `127.0.0.1`
+as your DNS server.
+
+-----
+
 Now start Focus:
 
     sudo python focus.py &


### PR DESCRIPTION
Simple instructions how to configure DNS on Mac OS X to work with Focus.
