### PR TITLE
Failback nameservers

### DIFF
--- a/focus.py
+++ b/focus.py
@@ -28,6 +28,7 @@ import socket
 import logging
 import time
 import os
+import time
 from os.path import exists
 from datetime import datetime
 import json
@@ -335,6 +336,7 @@ if __name__ == "__main__":
     cli_parser = OptionParser()
     cli_parser.add_option("-l", "--log", dest="log", default=None)
     cli_parser.add_option("-n", "--nameserver", dest="nameserver", default=None)
+    cli_parser.add_option("-w", "--wait", dest="wait", default=False, action="store_true")
     cli_options, cli_args = cli_parser.parse_args()
 
     logging.basicConfig(
@@ -363,6 +365,12 @@ if __name__ == "__main__":
     if not nameservers:
         if cli_options.nameserver:
             nameservers.append(cli_options.nameserver)
+        elif cli_options.wait:
+            while not nameservers:
+                nameservers = load_nameservers(resolv_conf)
+                nameservers.remove(config["bind_ip"])
+                time.sleep(5)
+
         else:
             raise Exception("you need at least one other nameserver in %s" %
             resolv_conf)

--- a/focus.py
+++ b/focus.py
@@ -334,6 +334,7 @@ def clean_up_pid():
 if __name__ == "__main__":
     cli_parser = OptionParser()
     cli_parser.add_option("-l", "--log", dest="log", default=None)
+    cli_parser.add_option("-n", "--nameserver", dest="nameserver", default=None)
     cli_options, cli_args = cli_parser.parse_args()
 
     logging.basicConfig(
@@ -347,10 +348,10 @@ if __name__ == "__main__":
     atexit.register(clean_up_pid)
     
     config.update(load_config())
-    nameservers = load_nameservers(resolv_conf)
     refresh_blacklist()    
     
     
+    nameservers = load_nameservers(resolv_conf)
     if config["bind_ip"] not in nameservers:
         raise Exception("%s not a nameserver in %s, please add it" %
             (config["bind_ip"], resolv_conf))
@@ -360,7 +361,10 @@ if __name__ == "__main__":
     nameservers.remove(config["bind_ip"])
     
     if not nameservers:
-        raise Exception("you need at least one other nameserver in %s" %
+        if cli_options.nameserver:
+            nameservers.append(cli_options.nameserver)
+        else:
+            raise Exception("you need at least one other nameserver in %s" %
             resolv_conf)
 
     # create our main server socket


### PR DESCRIPTION
Adds two options to focus.py:

-n / --nameserver <nameserver> To add a failback nameserver in case no alternate nameservers can be found
-w / --wait to wait for alternate nameservers to be available

**Note**: This branch hasn't been tested yet (due to lack of time), so it should be tested first.
