### PR TITLE
Check if bind_ip nameserver is present

### DIFF
--- a/focus.py
+++ b/focus.py
@@ -374,7 +374,8 @@ if __name__ == "__main__":
                 resolv_conf)
             while not nameservers:
                 nameservers = load_nameservers(resolv_conf)
-                nameservers.remove(config["bind_ip"])
+                if config["bind_ip"] in nameservers:
+                    nameservers.remove(config["bind_ip"])
                 time.sleep(5)
 
             log.info("found an alternative nameserver")


### PR DESCRIPTION
When no nameservers are present, nameservers.remove(..) results in an
error. This change checks if bind_ip is present in the list before
removing it.
