### PR TITLE
Drop privileges

### DIFF
--- a/focus.py
+++ b/focus.py
@@ -374,8 +374,8 @@ if __name__ == "__main__":
                 resolv_conf)
             while not nameservers:
                 nameservers = load_nameservers(resolv_conf)
-                if config["bind_ip"] in nameservers:
-                    nameservers.remove(config["bind_ip"])
+                try: nameservers.remove(config["bind_ip"])
+                except ValueError: pass
                 time.sleep(5)
 
             log.info("found an alternative nameserver")


### PR DESCRIPTION
focus running as root when it really only needs to for long enough to bind a privileged socket irks me.

This is a sample but largely untested implementation, however before I go nuts fleshing it out I thought I'd get your opinion on the best way to do this:
1. drop `euid` to an unprivileged user, come cleanup time reset to `0` and cleanup. This is the easiest to implement and also the easiest to exploit, since a call to `os.seteuid(0)` will leave the process running as root again.
2. Drop privs super early, arrange for pidfile, logs, etc all to be located somewhere writable by the unprivileged user. This is probably the best solution, since it leaves the programming running as root for the minimal amount of time.
3. Open everything as root, preserve FD's to everything we're going to subsequently need, drop privileges and jump through some hoops when it comes time to exit (nuking the pidfile for example).

Personally I can't decide between 2 and 3. `2` makes the most sense to me since this is essentially designed to be run per-user and not as a daemon, the necessity to be root is an implementation detail.

I'm happy to work on this, but since it will require some fairly invasive changes to the codebase I would like some feedback early.

Cheers

Richo
